### PR TITLE
bugfix: dump nil instead of empty string

### DIFF
--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -135,7 +135,11 @@ module Tod
     end
 
     def self.dump(time_of_day)
-      time_of_day.to_s
+      if time_of_day.to_s == ''
+        nil
+      else
+        time_of_day.to_s
+      end
     end
 
     def self.load(time)


### PR DESCRIPTION
ActiveRecord serialize postgres bug:
PG::InvalidDatetimeFormat: ERROR:  invalid input syntax for type time: ""
