### PR TITLE
Added distance_to to time_of_day

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,6 +63,12 @@ TimeOfDay includes Comparable.
     TimeOfDay.new(9) == TimeOfDay.new(9)           # => true
     TimeOfDay.new(10) > TimeOfDay.new(9)           # => true
 
+Distance
+--------------------
+
+    TimeOfDay.new(9).distance_to(TimeOfDay.new(17)) # => 28800
+    TimeOfDay.new(20).distance_to(TimeOfDay.new(2)) # => 21600
+
 Formatting
 ----------
 

--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -64,6 +64,22 @@ module Tod
       strftime "%H:%M:%S"
     end
 
+    # Return distance in seconds to the other object
+    # This method always returns a positive distance, so if received object is lower than self
+    # this method will calculate as the received time is from the following day
+    def distance_to(other)
+      this = TimeOfDay.from_second_of_day @second_of_day
+      if other >= this
+        (other.to_i - this.to_i)
+      else
+        start_of_day   = TimeOfDay.new(0,0,0)
+        end_of_day     = TimeOfDay.new(23,59,59)
+        duration_day_1 = (end_of_day.to_i - this.to_i) + 1
+        duration_day_2 = (other.to_i - start_of_day.to_i)
+        duration_day_1 + duration_day_2
+      end
+    end
+
     # Return a new TimeOfDay num_seconds greater than self. It will wrap around
     # at midnight.
     def +(num_seconds)
@@ -75,6 +91,8 @@ module Tod
     def -(num_seconds)
       TimeOfDay.from_second_of_day @second_of_day - num_seconds
     end
+
+
 
     # Returns a Time instance on date using self as the time of day
     # Optional time_zone will build time in that zone

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -206,4 +206,26 @@ class TimeOfDayTest < Test::Unit::TestCase
       end
     end
   end
+
+  context "distance_to" do
+    should "work when first time is lower than the second one" do
+      distance_expected = 4 * 60 * 60 + 30 * 60 + 30 # 4 hours, 30 min and 30 sec later
+      tod1 = TimeOfDay.new 8,30
+      tod2 = TimeOfDay.new 13,00,30
+      distance = tod1.distance_to(tod2)
+      assert_equal distance, distance_expected
+    end
+    should "work when first time is greater than the second one" do
+      distance_expected = 4 * 60 * 60 + 30 * 60 + 30 # 4 hours, 30 min and 30 sec later
+      tod1 = TimeOfDay.new 22,30
+      tod2 = TimeOfDay.new 3,00,30
+      distance = tod1.distance_to(tod2)
+      assert_equal distance, distance_expected
+    end
+    should "be zero when both times are equal" do
+      tod1 = TimeOfDay.new 3,00,30
+      distance = tod1.distance_to(tod1)
+      assert_equal distance, 0
+    end
+  end
 end


### PR DESCRIPTION
This new method allows to compare to time_of_day objects and get theirs distance in seconds.
It returns the right distance even when start and end time are in different days.
