### PR TITLE
Increase compatibility with postgres time type.

### DIFF
--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -33,6 +33,16 @@ module Tod
       \z
     /x
 
+    PARSE_END_OF_DAY_REGEX = /
+      \A
+      (24)
+      :?
+      (00)?
+      :?
+      (00)?
+      \z
+    /x
+
     NUM_SECONDS_IN_DAY = 86400
     NUM_SECONDS_IN_HOUR = 3600
     NUM_SECONDS_IN_MINUTE = 60
@@ -124,12 +134,16 @@ module Tod
       tod_string = tod_string.to_s
       tod_string = tod_string.strip
       tod_string = tod_string.downcase
-      if PARSE_24H_REGEX =~ tod_string || PARSE_12H_REGEX =~ tod_string
+      if PARSE_24H_REGEX =~ tod_string || PARSE_12H_REGEX =~ tod_string || PARSE_END_OF_DAY_REGEX =~ tod_string
         hour, minute, second, a_or_p = $1.to_i, $2.to_i, $3.to_i, $4
         if hour == 12 && a_or_p == "a"
           hour = 0
         elsif hour < 12 && a_or_p == "p"
           hour += 12
+        end
+
+        if hour == 24
+          hour, minute, second = 23, 59, 59
         end
 
         new hour, minute, second

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -85,9 +85,9 @@ class TimeOfDayTest < Test::Unit::TestCase
   should_parse "12a",          0, 0, 0
   should_parse "12p",         12, 0, 0
 
+  should_parse "24:00:00",    23,59,59
+
   should_not_parse "-1:30"
-  should_not_parse "24:00:00"
-  should_not_parse "24"
   should_not_parse "00:60"
   should_not_parse "00:00:60"
   should_not_parse "13a"


### PR DESCRIPTION
Allow 24:00:00 for time value when parsing, as this is a valid value for PostgreSQL. I got errors when I tried to use Tod with previous entries, that were already in DB (the value of 24:00:00 is created by using end_of_day). It would be hard to allow value of 24:00:00 internally, thus it is casted as 23:59:59.

It could be useful to also allow decimal seconds, but I currently use time(0) as column type to avoid issues with this.

More information:
http://www.postgresql.org/docs/9.3/static/datatype-datetime.html
