### PR TITLE
return nil unless `other` is comparable

### DIFF
--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -57,7 +57,7 @@ module Tod
     end
 
     def <=>(other)
-      return unless other.respond_to(:second_of_day)
+      return unless other.respond_to?(:second_of_day)
       @second_of_day <=> other.second_of_day
     end
 

--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -57,6 +57,7 @@ module Tod
     end
 
     def <=>(other)
+      return unless other.respond_to(:second_of_day)
       @second_of_day <=> other.second_of_day
     end
 


### PR DESCRIPTION
[This](https://github.com/ruby/ruby/commit/d781caaf313b8649948c107bba277e5ad7307314) commit caused the following warnings to appear when comparing objects.

    Comparable#== will no more rescue exceptions of #<=> in the next release.
    Return nil in #<=> if the comparison is inappropriate or avoid such comparison.

This fix returns nil unless `other` is comparable in the same style as [a similar fix](https://github.com/rdoc/rdoc/commit/23c276de) in rdoc