### PR TITLE
Adds compatibility for time_select helper and fixes "overlaps?" for certain cases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tod (2.0.0)
+    tod (2.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -33,7 +33,7 @@ module Tod
 
     # Returns true if ranges overlap, false otherwise.
     def overlaps?(other)
-      a, b = [self, other].map(&:range).sort_by(&:first)
+      a, b = [self, other].map(&:range)
       op = a.exclude_end? ? :> : :>=
       a.last.send(op, b.first)
     end

--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -35,20 +35,18 @@ module Tod
     def overlaps?(other)
       max_seconds = TimeOfDay::NUM_SECONDS_IN_DAY
 
-      # Standard case
-      a, b = [self, other].map(&:range)
-      a, b = [a, b].sort_by(&:first)
+      # Standard case, when Shifts are on the same day
+      a, b = [self, other].map(&:range).sort_by(&:first)
       op = a.exclude_end? ? :> : :>=
       return true if a.last.send(op, b.first)
 
-      # Special cases
-      if (a.last > max_seconds) || (b.last > max_seconds)
-        a = Range.new(a.first, a.last - max_seconds, a.exclude_end?) if a.last > max_seconds
-        b = Range.new(b.first, b.last - max_seconds, b.exclude_end?) if b.last > max_seconds
-        a, b = [a, b].sort_by(&:last)
-        b.last.send(op, a.last) && a.last.send(op, b.first)
-      end
-      
+      # Special cases, when Shifts span to the next day
+      return false if (a.last < max_seconds) && (b.last < max_seconds)
+
+      a = Range.new(a.first, a.last - max_seconds, a.exclude_end?) if a.last > max_seconds
+      b = Range.new(b.first, b.last - max_seconds, b.exclude_end?) if b.last > max_seconds
+      a, b = [a, b].sort_by(&:last)
+      b.last.send(op, a.last) && a.last.send(op, b.first)
     end
 
     def contains?(shift)

--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -33,9 +33,22 @@ module Tod
 
     # Returns true if ranges overlap, false otherwise.
     def overlaps?(other)
+      max_seconds = TimeOfDay::NUM_SECONDS_IN_DAY
+
+      # Standard case
       a, b = [self, other].map(&:range)
+      a, b = [a, b].sort_by(&:first)
       op = a.exclude_end? ? :> : :>=
-      a.last.send(op, b.first)
+      return true if a.last.send(op, b.first)
+
+      # Special cases
+      if (a.last > max_seconds) || (b.last > max_seconds)
+        a = Range.new(a.first, a.last - max_seconds, a.exclude_end?) if a.last > max_seconds
+        b = Range.new(b.first, b.last - max_seconds, b.exclude_end?) if b.last > max_seconds
+        a, b = [a, b].sort_by(&:last)
+        b.last.send(op, a.last) && a.last.send(op, b.first)
+      end
+      
     end
 
     def contains?(shift)

--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -2,7 +2,7 @@ module Tod
   class TimeOfDay
     include Comparable
 
-    attr_reader :hour, :minute, :second, :second_of_day
+    attr_reader :hour, :minute, :second, :second_of_day, :day, :month, :year
     alias_method :min, :minute
     alias_method :sec, :second
     alias_method :to_i, :second_of_day
@@ -46,6 +46,9 @@ module Tod
       @hour = Integer(h)
       @minute = Integer(m)
       @second = Integer(s)
+      @day = Integer(1)
+      @month = Integer(1)
+      @year = Integer(2000)
 
       raise ArgumentError, "hour must be between 0 and 23" unless (0..23).include?(@hour)
       raise ArgumentError, "minute must be between 0 and 59" unless (0..59).include?(@minute)

--- a/test/tod/shift_test.rb
+++ b/test/tod/shift_test.rb
@@ -44,7 +44,7 @@ describe "Shift" do
       shift2 = Tod::Shift.new(Tod::TimeOfDay.new(13), Tod::TimeOfDay.new(15))
       assert shift1.overlaps?(shift2)
 
-      # Additional Testing for shifts that Range from one day to another
+      # Additional Testing for Shifts that span from one day to another
       cases = [
         [5, 8, 7, 2],
         [7, 2, 1, 8],
@@ -72,7 +72,7 @@ describe "Shift" do
       shift2 = Tod::Shift.new(Tod::TimeOfDay.new(9), Tod::TimeOfDay.new(12))
       refute shift1.overlaps?(shift2)
 
-      # Additional Testing for shifts that Range from one day to another
+      # Additional Testing for Shifts that span from one day to another
       cases = [
         [7, 8, 1, 5],
         [1, 5, 7, 8],

--- a/test/tod/shift_test.rb
+++ b/test/tod/shift_test.rb
@@ -43,12 +43,49 @@ describe "Shift" do
       shift1 = Tod::Shift.new(Tod::TimeOfDay.new(12), Tod::TimeOfDay.new(18))
       shift2 = Tod::Shift.new(Tod::TimeOfDay.new(13), Tod::TimeOfDay.new(15))
       assert shift1.overlaps?(shift2)
+
+      # Additional Testing for shifts that Range from one day to another
+      cases = [
+        [5, 8, 7, 2],
+        [7, 2, 1, 8],
+        [7, 2, 5, 8],
+        [4, 8, 1, 5],
+        [1, 5, 4, 8],
+        [7, 2, 1, 4],
+        [1, 4, 7, 2],
+        [1, 4, 3, 2],
+        [5, 8, 7, 2],
+        [7, 2, 8, 3],
+        [7, 2, 6, 3],
+        [7, 2, 1, 8]
+      ]
+
+      cases.each do |c|
+        shift1 = Tod::Shift.new(Tod::TimeOfDay.new(c[0]), Tod::TimeOfDay.new(c[1]))
+        shift2 = Tod::Shift.new(Tod::TimeOfDay.new(c[2]), Tod::TimeOfDay.new(c[3]))
+        assert shift1.overlaps?(shift2), "Failed with args: #{c}"
+      end
     end
 
     it "is false when shifts don't overlap" do
       shift1 = Tod::Shift.new(Tod::TimeOfDay.new(1), Tod::TimeOfDay.new(5))
       shift2 = Tod::Shift.new(Tod::TimeOfDay.new(9), Tod::TimeOfDay.new(12))
       refute shift1.overlaps?(shift2)
+
+      # Additional Testing for shifts that Range from one day to another
+      cases = [
+        [7, 8, 1, 5],
+        [1, 5, 7, 8],
+        [7, 2, 3, 4],
+        [3, 4, 5, 2],
+        [1, 5, 9, 12]
+      ]
+
+      cases.each do |c|
+        shift1 = Tod::Shift.new(Tod::TimeOfDay.new(c[0]), Tod::TimeOfDay.new(c[1]))
+        shift2 = Tod::Shift.new(Tod::TimeOfDay.new(c[2]), Tod::TimeOfDay.new(c[3]))
+        refute shift1.overlaps?(shift2), "Failed with args: #{c}"
+      end
     end
 
     it "is true when shifts touch with inclusive end" do


### PR DESCRIPTION
Hi,

This fixes might be specific for my project, but I'm sharing them in case they are helpful for the community.

1. time_select compatibility: rails has a helper method that renders a time selector on views, however, the object must have Date and Time attributes (although it does ignore the Date attributes...), so this little change adds a placeholder day that will be ignored AFAIK.
2. overlaps?: as I understood this method, it should return a boolean that represents if two "Shifts" overlap in time, I found some cases that failed according to my logic, for example, calling
```ruby
shift1 = Tod::Shift.new(Tod::TimeOfDay.new(7), Tod::TimeOfDay.new(2))
shift2 = Tod::Shift.new(Tod::TimeOfDay.new(1), Tod::TimeOfDay.new(4))
```
would represent something like this:
![timeline](https://cloud.githubusercontent.com/assets/972669/7898349/f16579b6-06c2-11e5-8bbe-5fb3d8c51ea3.jpg)

And `overlaps?` should return `true` AFAIK, which it does not.

I added a few more test cases on tests, as there are some edge cases to be considered.

One more time, I don't know if this is the expected behavior for all projects, and how the author planned them, but this proved to be useful in my particular case