### PR TITLE
Add slide method for shift to make manipulation easier

### DIFF
--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -62,5 +62,10 @@ module Tod
     def exclude_end?
       @exclude_end
     end
+    
+    # Move start and end by a number of seconds and return new shift.
+    def slide(seconds)
+      self.class.new(beginning + seconds, ending + seconds, exclude_end?)
+    end
   end
 end

--- a/test/tod/shift_test.rb
+++ b/test/tod/shift_test.rb
@@ -203,4 +203,51 @@ describe "Shift" do
       assert shift.include?(value)
     end
   end
+
+  describe "slide" do
+    it "handles positive numbers" do
+      slide = 30 * 60 # 30 minutes in seconds
+
+      beginning_expected = Tod::TimeOfDay.new 10, 30
+      ending_expected = Tod::TimeOfDay.new 16, 30
+
+      beginning  = Tod::TimeOfDay.new 10
+      ending  = Tod::TimeOfDay.new 16
+      shift = Tod::Shift.new(beginning, ending, false).slide(slide)
+
+      assert_equal beginning_expected, shift.beginning
+      assert_equal ending_expected, shift.ending
+      refute shift.exclude_end?
+    end
+
+    it "handles negative numbers" do
+      slide = -30 * 60 # -30 minutes in seconds
+
+      beginning_expected = Tod::TimeOfDay.new 9, 30
+      ending_expected = Tod::TimeOfDay.new 15, 30
+
+      beginning  = Tod::TimeOfDay.new 10
+      ending  = Tod::TimeOfDay.new 16
+      shift = Tod::Shift.new(beginning, ending, false).slide(slide)
+
+      assert_equal beginning_expected, shift.beginning
+      assert_equal ending_expected, shift.ending
+      refute shift.exclude_end?
+    end
+
+    it "handles ActiveSupport::Duration" do
+      slide = 30.minutes
+
+      beginning_expected = Tod::TimeOfDay.new 10, 30
+      ending_expected = Tod::TimeOfDay.new 16, 30
+
+      beginning  = Tod::TimeOfDay.new 10
+      ending  = Tod::TimeOfDay.new 16
+      shift = Tod::Shift.new(beginning, ending, false).slide(slide)
+
+      assert_equal beginning_expected, shift.beginning
+      assert_equal ending_expected, shift.ending
+      refute shift.exclude_end?
+    end
+  end
 end

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -151,6 +151,12 @@ describe "TimeOfDay" do
       result = original + 15
       refute_equal original.object_id, result.object_id
     end
+
+    it "handles ActiveSupport::Duration" do
+      original = Tod::TimeOfDay.new(8,0,0)
+      result = original + 10.minutes
+      assert_equal Tod::TimeOfDay.new(8,10,0), result
+    end
   end
 
   describe "subtraction" do
@@ -170,6 +176,12 @@ describe "TimeOfDay" do
       original = Tod::TimeOfDay.new(8,0,0)
       result = original - 15
       refute_equal original.object_id, result.object_id
+    end
+
+    it "handles ActiveSupport::Duration" do
+      original = Tod::TimeOfDay.new(8,0,0)
+      result = original - 10.minutes
+      assert_equal Tod::TimeOfDay.new(7,50,0), result
     end
   end
 


### PR DESCRIPTION
Added a convenience method to slide shift down a little for easier manipulation in comparisons.  Could do this with `+` but maybe that would be misleading?