### PR TITLE
Add arel_extensions for TimeOfDay

### DIFF
--- a/lib/tod/arel_extensions.rb
+++ b/lib/tod/arel_extensions.rb
@@ -1,0 +1,25 @@
+require 'arel'
+
+module Tod
+  module ArelDepthFirstExtensions
+    def self.included(base)
+      base.send :alias_method, :visit_Tod_TimeOfDay, :terminal
+    end
+  end
+
+  module ArelDotExtensions
+    def self.included(base)
+      base.send :alias_method, :visit_Tod_TimeOfDay, :visit_String
+    end
+  end
+
+  module ArelToSqlExtensions
+    def visit_Tod_TimeOfDay(o, collector=nil)
+      quote Tod::TimeOfDay.dump(o)
+    end
+  end
+end
+
+Arel::Visitors::DepthFirst.send :include, Tod::ArelDepthFirstExtensions
+Arel::Visitors::Dot.send :include, Tod::ArelDotExtensions
+Arel::Visitors::ToSql.send :include, Tod::ArelToSqlExtensions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'bundler/setup'
 require 'active_support/time'
 require 'tod'
 require 'tod/core_extensions'
+require 'tod/arel_extensions'
 require 'minitest/autorun'
 require 'pry'
 

--- a/test/tod/time_of_day_serializable_attribute_test.rb
+++ b/test/tod/time_of_day_serializable_attribute_test.rb
@@ -30,4 +30,13 @@ describe "TimeOfDay with ActiveRecord Serializable Attribute" do
       assert_equal order.time, nil
     end
   end
+
+  describe "Order.where" do
+    it "handles TimeOfDay as a parameter" do
+      tod = Tod::TimeOfDay.new(11, 11)
+      expected = Order.create!(time: tod)
+      actual = Order.where(time: tod).first
+      assert_equal expected, actual
+    end
+  end
 end

--- a/tod.gemspec
+++ b/tod.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activerecord", ">= 3.0.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "pry"
+  s.add_development_dependency "arel"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This is a patch for #28 

I didn't add it to the `core_extensions` because I wasn't sure that everyone would have Arel.  So to use it you would have to obviously `require 'tod/arel_extensions'`.