### PR TITLE
Add database quoting for TOD instances

### DIFF
--- a/lib/tod.rb
+++ b/lib/tod.rb
@@ -1,3 +1,5 @@
 require 'tod/time_of_day'
 require 'tod/shift'
 require 'tod/conversions'
+require 'tod/railtie' if defined?(Rails)
+

--- a/lib/tod/quoting.rb
+++ b/lib/tod/quoting.rb
@@ -1,0 +1,9 @@
+module Tod
+  module Quoting
+    def quote(value, *args)
+      # RTTI makes this super rigid; sadly, when in Rome....
+      value.kind_of?(Tod::TimeOfDay) ? super(value.to_s, *args) : super
+    end
+  end
+end
+

--- a/lib/tod/railtie.rb
+++ b/lib/tod/railtie.rb
@@ -1,0 +1,15 @@
+require 'tod/time_of_day'
+require 'tod/quoting'
+
+module Tod
+  require 'rails'
+
+  class Railtie < Rails::Railtie
+    initializer 'tod.add_time_of_day_quoting_to_postgres' do
+      ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.instance_eval { include Tod::Quoting }
+    end
+
+    # TODO: Initializes for other databases?
+  end
+end
+

--- a/test/tod/quoting_test.rb
+++ b/test/tod/quoting_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib', 'tod', 'quoting'))
+
+describe Tod::Quoting do
+  before do
+    ActiveRecord::ConnectionAdapters::SQLite3Adapter.instance_eval { include Tod::Quoting }
+  end
+
+  describe "#quote" do
+    it "returns a value the database will understand" do
+      time_of_day = Tod::TimeOfDay.new(7, 30)
+      quoted_time_of_day = ActiveRecord::Base.connection.quote(time_of_day)
+      assert_equal "'#{time_of_day}'", quoted_time_of_day
+    end
+  end
+end
+


### PR DESCRIPTION
I would like to use TOD instances in database queries like so:

``` ruby
Wibble.where('some_time < :zero_dark_thirty', zero_dark_thirty: Tod::TimeOfDay.new(4, 30))
```

Sadly, AR doesn't provide a mechanism for classes to make themselves quotable (something analogous to #to_s would be nice), and the default for unknown types is #to_yaml (WAT?), so changing quoting requires a small addition to the AR::ConnectionAdapter.

This is that small addition.

It's been some time since I've used a database other than Postgres in any serious way, so I've only included the patch for the Postgres adapter in the Railtie.  I'm open to suggestions for other adapters from more knowledgeable folks.
