### PR TITLE
Require 'Date' in date_extensions.rb

### DIFF
--- a/lib/tod/date_extensions.rb
+++ b/lib/tod/date_extensions.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Tod
   module DateExtensions
     # Returns a local Time instance with this date and time_of_day


### PR DESCRIPTION
I used `tod` to write a little command-line script that would return a different emoji for my terminal prompt based on the time of day (:coffee: in the AM, :beer: at 6:30, 🌒 when I need to go tf to bed, etc). I was getting the following error:
```
~/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/tod-2.0.2/lib/tod/date_extensions.rb:15:in `<top (required)>': uninitialized constant Date (NameError)
	from /Users/ambirdsall/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/ambirdsall/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/ambirdsall/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/tod-2.0.2/lib/tod/core_extensions.rb:1:in `<top (required)>'
	from /Users/ambirdsall/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/ambirdsall/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
```

This adds an explicit `require 'Date'` to the offending file so that this can be used in a self-contained way outside of environments like rails where the `Date` class comes preloaded.

cf. https://github.com/neo4jrb/neo4j/issues/852