### PR TITLE
Fix passing Time to serialized attribute for Rails 5

### DIFF
--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -185,7 +185,7 @@ module Tod
       elsif time_of_day.to_s == ''
         nil
       else
-        time_of_day.to_s
+        Tod::TimeOfDay(time_of_day).to_s
       end
     end
 

--- a/test/tod/time_of_day_serializable_attribute_test.rb
+++ b/test/tod/time_of_day_serializable_attribute_test.rb
@@ -22,11 +22,18 @@ describe "TimeOfDay with ActiveRecord Serializable Attribute" do
   end
 
   describe ".load" do
-    it "loads set time" do
+    it "loads set Tod::TimeOfDay" do
       time_of_day = Tod::TimeOfDay.new(9, 30)
       order = Order.create!(time: time_of_day)
       order.reload
       assert_equal order.time, time_of_day
+    end
+
+    it "loads set Time" do
+      time_of_day = Time.new(2015, 10, 21, 16, 29, 0, "-07:00")
+      order = Order.create!(time: time_of_day)
+      order.reload
+      assert_equal order.time, Tod::TimeOfDay.new(16, 29)
     end
 
     it "returns nil if time is not set" do


### PR DESCRIPTION
The change in Rails 5 in how time zones are handled for time columns has broken the ability to pass a Time object to an attribute serialized as `Tod::TimeOfDay`. See the failing test commit for an example - thanks!