### PR TITLE
Add support for custom formatting with good defaults

### DIFF
--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -42,6 +42,12 @@ module Tod
     NUM_SECONDS_IN_HOUR = 3600
     NUM_SECONDS_IN_MINUTE = 60
 
+    FORMATS = {
+      short: "%-l:%M %P",
+      medium: "%-l:%M:%S %P",
+      time: "%H:%M"
+    }
+
     def initialize(h, m=0, s=0)
       @hour = Integer(h)
       @minute = Integer(m)
@@ -81,9 +87,18 @@ module Tod
       Time.local(2000,1,1, @hour, @minute, @second).strftime(format_string)
     end
 
-    def to_s
-      strftime "%H:%M:%S"
+    def to_formatted_s(format = :default)
+      if formatter = FORMATS[format]
+        if formatter.respond_to?(:call)
+          formatter.call(self).to_s
+        else
+          strftime(formatter)
+        end
+      else
+        strftime "%H:%M:%S"
+      end
     end
+    alias_method :to_s, :to_formatted_s
 
     # Return a new TimeOfDay num_seconds greater than self. It will wrap around
     # at midnight.

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -133,10 +133,41 @@ describe "TimeOfDay" do
     end
   end
 
+  describe "to_formatted_s" do
+    it "has a default format" do
+      assert_equal "08:15:30", Tod::TimeOfDay.new(8,15,30).to_formatted_s
+      assert_equal "22:10:45", Tod::TimeOfDay.new(22,10,45).to_formatted_s
+    end
+
+    it "has a short format" do
+      assert_equal "8:15 am", Tod::TimeOfDay.new(8,15,30).to_formatted_s(:short)
+      assert_equal "10:10 pm", Tod::TimeOfDay.new(22,10,45).to_formatted_s(:short)
+    end
+
+    it "has a medium format" do
+      assert_equal "8:15:30 am", Tod::TimeOfDay.new(8,15,30).to_formatted_s(:medium)
+      assert_equal "10:10:45 pm", Tod::TimeOfDay.new(22,10,45).to_formatted_s(:medium)
+    end
+
+    it "has an ActiveSupport compatible time format" do
+      assert_equal "08:15", Tod::TimeOfDay.new(8,15,30).to_formatted_s(:time)
+      assert_equal "22:10", Tod::TimeOfDay.new(22,10,45).to_formatted_s(:time)
+    end
+
+    it "evaluates custom lambda lambda formats" do
+      begin
+        Tod::TimeOfDay::FORMATS[:lambda] = -> (t) { t.strftime("%H%M 😎") }
+        assert_equal "1337 😎", Tod::TimeOfDay.new(13,37).to_formatted_s(:lambda)
+      ensure
+        Tod::TimeOfDay::FORMATS.delete(:lambda)
+      end
+    end
+  end
+
   describe "to_s" do
-    it "formats to HH:MM:SS" do
-      assert_equal "08:15:30", Tod::TimeOfDay.new(8,15,30).to_s
-      assert_equal "22:10:45", Tod::TimeOfDay.new(22,10,45).to_s
+    it "is aliased to to_formatted_s" do
+      t = Tod::TimeOfDay.new(8,15,30)
+      assert_equal t.to_formatted_s, t.to_s
     end
   end
 


### PR DESCRIPTION
Resolves #49 by adding a similar `#to_formatted_s` interface to `Tod::TimeOfDay` as with ActiveSupport's extended `Time` and `Date` interfaces.

``` ruby
time = Tod::TimeOfDay.new(8,15,30)
time.to_s #=> "08:15:30" # Preserves existing behaviour
time.to_formatted_s #=> "08:15:30"
time.to_formatted_s(:short) #=> "8:15 am"
time.to_formatted_s(:medium) #=> "8:15:30 am"
time.to_formatted_s(:time) #=> "08:15" # Compatible with the default `:time` format in ActiveSupport
```

Some design decisions for your consideration:

1. I opted to go with `:short` and `:medium` formats based on the styles found in [NSDateFormatterStyle from Cocoa](https://developer.apple.com/documentation/foundation/nsdateformatterstyle?language=objc). Apple has a very extensive localization framework and if they've settled on these names then it's probably with good reason. I couldn't find any meaningful examples in Rails or ActiveSupport, except `:time`.
2. There's a `:time` format that matches ActiveSupport. This means if you're using Rails you can go `to_s(:time)` with either `Date`, `Time`, or `Tod::TimeOfDay` and get the same formatting.
3. I defaulted to lowercase `am` over uppercase `AM` because `Tod::TimeOfDay::WORDS` defaults to the lowercase variants. My recommendation would be to move toward uppercase because it's the default style for US formatting. Most libraries default to US formatting unless specified. If you're agreeable I will submit another PR (I say this as someone who does not use the US locale).
4. Do you want me to update the README, or is this something you'd prefer to do?

This works out of the box with [I18n](https://github.com/svenfuchs/i18n) meaning you can go `<%= l(some_tod_instance, formats: :foo) %>` and it will work as expected. See http://guides.rubyonrails.org/i18n.html#adding-date-time-formats.

All feedback welcome.