### PR TITLE
reactivate 24h support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,32 +6,31 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.0.2)
-      activesupport (= 5.0.2)
-    activerecord (5.0.2)
-      activemodel (= 5.0.2)
-      activesupport (= 5.0.2)
-      arel (~> 7.0)
-    activesupport (5.0.2)
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activerecord (5.2.0)
+      activemodel (= 5.2.0)
+      activesupport (= 5.2.0)
+      arel (>= 9.0)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (7.1.4)
-    coderay (1.1.1)
+    arel (9.0.0)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
-    i18n (0.8.1)
-    method_source (0.8.2)
-    minitest (5.10.1)
-    pry (0.10.4)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
+    method_source (0.9.0)
+    minitest (5.11.3)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rake (12.0.0)
-    slop (3.6.0)
+      method_source (~> 0.9.0)
+    rake (12.3.1)
     sqlite3 (1.3.13)
     thread_safe (0.3.6)
-    tzinfo (1.2.2)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -48,4 +47,4 @@ DEPENDENCIES
   tzinfo
 
 BUNDLED WITH
-   1.14.6
+   1.16.3

--- a/README.markdown
+++ b/README.markdown
@@ -208,7 +208,7 @@ Rails Time Zone Support
 
 If Rails time zone support is loaded, Date#on and Tod::TimeOfDay#at will automatically use Time.zone.
 
-Active Record Serializable Attribute Support
+ActiveRecord Serializable Attribute Support
 =======================
 Tod::TimeOfDay implements a custom serialization contract for ActiveRecord serialize which allows to store Tod::TimeOfDay directly
 in a column of the time type.

--- a/test/tod/conversion_test.rb
+++ b/test/tod/conversion_test.rb
@@ -81,4 +81,11 @@ describe "TimeOfDay()" do
 
     assert_equal(tod, Tod::TimeOfDay.new(0, 00, 00))
   end
+
+  it "parses 24:00:00" do
+    t   = "24:00:00"
+    tod = Tod::TimeOfDay(t)
+
+    assert_equal(tod, Tod::TimeOfDay.new(24, 00, 00))
+  end
 end

--- a/test/tod/time_of_day_serializable_attribute_test.rb
+++ b/test/tod/time_of_day_serializable_attribute_test.rb
@@ -41,6 +41,13 @@ describe "TimeOfDay with ActiveRecord Serializable Attribute" do
       order.reload
       assert_nil order.time
     end
+
+    it "dump 24:00:00 and get it back" do
+      time_of_day = Tod::TimeOfDay.new(24, 0, 0)
+      order = Order.create!(time: time_of_day)
+      order.reload
+      assert_equal Tod::TimeOfDay.new(24), order.time
+    end
   end
 
   describe "Order.where" do

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -3,8 +3,8 @@ require_relative '../test_helper'
 describe "TimeOfDay" do
   describe "#initialize" do
     it "blocks invalid hours" do
-      assert_raises(ArgumentError) { Tod::TimeOfDay.new(-1) }
-      assert_raises(ArgumentError) { Tod::TimeOfDay.new 24 }
+      assert_raises(ArgumentError) { Tod::TimeOfDay.new -1 }
+      assert_raises(ArgumentError) { Tod::TimeOfDay.new 25 }
     end
 
     it "blocks invalid minutes" do
@@ -29,6 +29,10 @@ describe "TimeOfDay" do
 
     it "is 86399 at last second of day" do
       assert_equal 86399, Tod::TimeOfDay.new(23,59,59).second_of_day
+    end
+
+    it "is 86400 at beginning of next day" do
+      assert_equal 86400, Tod::TimeOfDay.new(24,0,0).second_of_day
     end
 
     it "have alias to_i" do
@@ -84,9 +88,12 @@ describe "TimeOfDay" do
   should_parse "12a",          0, 0, 0
   should_parse "12p",         12, 0, 0
 
+  should_parse "24:00:00",    24, 0, 0
+  should_parse "24:00",       24, 0, 0
+  should_parse "24",          24, 0, 0
+  should_parse "2400",        24, 0, 0
+
   should_not_parse "-1:30"
-  should_not_parse "24:00:00"
-  should_not_parse "24"
   should_not_parse "00:60"
   should_not_parse "00:00:60"
   should_not_parse "13a"
@@ -123,7 +130,7 @@ describe "TimeOfDay" do
       assert_equal Tod::TimeOfDay.new(8,20,0), Tod::TimeOfDay.new(8,20,00).round(300)
       assert_equal Tod::TimeOfDay.new(9,0,0), Tod::TimeOfDay.new(8,58,00).round(300)
       assert_equal Tod::TimeOfDay.new(8,0,0), Tod::TimeOfDay.new(8,02,29).round(300)
-      assert_equal Tod::TimeOfDay.new(0,0,0), Tod::TimeOfDay.new(23,58,29).round(300)
+      assert_equal Tod::TimeOfDay.new(24,0,0), Tod::TimeOfDay.new(23,58,29).round(300)
     end
   end
 
@@ -246,7 +253,7 @@ describe "TimeOfDay" do
     end
 
     it "handles positive numbers a day or more away" do
-      assert_equal Tod::TimeOfDay.new(0,0,0), Tod::TimeOfDay.from_second_of_day(86400)
+      assert_equal Tod::TimeOfDay.new(24,0,0), Tod::TimeOfDay.from_second_of_day(86400)
       assert_equal Tod::TimeOfDay.new(0,0,30), Tod::TimeOfDay.from_second_of_day(86430)
       assert_equal Tod::TimeOfDay.new(0,1,30), Tod::TimeOfDay.from_second_of_day(86490)
       assert_equal Tod::TimeOfDay.new(1,1,5), Tod::TimeOfDay.from_second_of_day(90065)


### PR DESCRIPTION
I've managed to get the 24h support working in rails > 5.1 even with saving to database and reload.