### PR TITLE
no exception on access of unparsable values in rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ gemfile:
   - gemfiles/4.1.gemfile
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile
+matrix:
+  include:
+    - rvm: 2.5.1
+      gemfile: gemfiles/5.2.gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    byebug (10.0.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     i18n (1.0.1)
@@ -27,6 +28,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rake (12.3.1)
     sqlite3 (1.3.13)
     thread_safe (0.3.6)
@@ -40,7 +44,7 @@ DEPENDENCIES
   activerecord (>= 3.0.0)
   arel
   minitest
-  pry
+  pry-byebug
   rake
   sqlite3
   tod!

--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,12 @@ parsable.
     Tod::TimeOfDay.try_parse "3:30pm"                   # => 15:30:00
     Tod::TimeOfDay.try_parse "foo"                      # => nil
 
+You can also give a block to parse to handle special input with your own logic.
+
+    Tod::TimeOfDay.parse "25" do |time_string|
+      Tod::TimeOfDay.new(time_string.to_i % 24)
+    end                                                 # => 01:00:00
+
 Values can be tested with Tod::TimeOfDay.parsable? to see if they can be parsed.
 
     Tod::TimeOfDay.parsable? "3:30pm"                   # => true

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'activerecord', '~> 5.2.1'
+
+gemspec :path=>"../"

--- a/lib/tod/conversions.rb
+++ b/lib/tod/conversions.rb
@@ -1,5 +1,5 @@
 module Tod
-  def TimeOfDay(obj_or_string)
+  def TimeOfDay(obj_or_string, &block)
     if obj_or_string.is_a?(TimeOfDay)
       obj_or_string
     elsif obj_or_string.respond_to?(:to_time_of_day)
@@ -9,7 +9,7 @@ module Tod
     elsif obj_or_string.is_a?(Date)
       TimeOfDay.new 0
     else
-      TimeOfDay.parse(obj_or_string)
+      TimeOfDay.parse(obj_or_string, &block)
     end
   end
 

--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -160,8 +160,10 @@ module Tod
     #   TimeOfDay.parse "3:25:58"                      # => 03:25:58
     #   TimeOfDay.parse "515p"                         # => 17:15:00
     #   TimeOfDay.parse "151253"                       # => 15:12:53
+    # You can give a block, that is called with the input if the string is not parsable.
+    # If no block is given an ArgumentError is raised if try_parse returns nil.
     def self.parse(tod_string)
-      try_parse(tod_string) || (raise ArgumentError, "Invalid time of day string")
+      try_parse(tod_string) || (block_given? ? yield(tod_string) : raise(ArgumentError, "Invalid time of day string"))
     end
 
     # Same as parse(), but return nil if not parsable (instead of raising an error)
@@ -200,15 +202,16 @@ module Tod
     end
 
     def self.dump(time_of_day)
-      if time_of_day.is_a? Hash
-        # rails multiparam attribute
-        hour,minute,second = time_of_day[4], time_of_day[5], time_of_day[6]
-        ::Tod::TimeOfDay.new(hour, minute, second).to_s
-      elsif time_of_day.to_s == ''
-        nil
-      else
-        Tod::TimeOfDay(time_of_day).to_s
-      end
+      time_of_day =
+        if time_of_day.is_a? Hash
+           # rails multiparam attribute
+           # get hour, minute and second and construct new TimeOfDay object
+          ::Tod::TimeOfDay.new(time_of_day[4], time_of_day[5], time_of_day[6])
+        else
+          # return nil, if input is not parsable
+          Tod::TimeOfDay(time_of_day){}
+        end
+      time_of_day.to_s if time_of_day
     end
 
     def self.load(time)

--- a/test/tod/time_of_day_serializable_attribute_test.rb
+++ b/test/tod/time_of_day_serializable_attribute_test.rb
@@ -19,6 +19,18 @@ describe "TimeOfDay with ActiveRecord Serializable Attribute" do
       order = Order.create!({"time(4i)" => "8", "time(5i)" => "6", "time(6i)" => "5"})
       assert_equal Tod::TimeOfDay.new(8,6,5), order.time
     end
+
+    it "should not raise Exception on access of unparsable values" do
+      order = Order.new(time: 'unparsable')
+      order.time
+      assert order.valid?
+    end
+
+    it "should dump unparsable values to nil" do
+      assert_nil Tod::TimeOfDay.dump('')
+      assert_nil Tod::TimeOfDay.dump('unparsable')
+      assert_nil Tod::TimeOfDay.dump(nil)
+    end
   end
 
   describe ".load" do

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 describe "TimeOfDay" do
   describe "#initialize" do
     it "blocks invalid hours" do
-      assert_raises(ArgumentError) { Tod::TimeOfDay.new -1 }
+      assert_raises(ArgumentError) { Tod::TimeOfDay.new(-1) }
       assert_raises(ArgumentError) { Tod::TimeOfDay.new 25 }
     end
 
@@ -107,6 +107,11 @@ describe "TimeOfDay" do
     assert_equal false, Tod::TimeOfDay.parsable?(nil)
     assert_nil Tod::TimeOfDay.try_parse(nil)
     assert_raises(ArgumentError) { Tod::TimeOfDay.parse(nil) }
+  end
+
+  it "executes block on parsing failure and return result instead" do
+    assert_equal Tod::TimeOfDay.new(1), Tod::TimeOfDay.parse('25:00:00') { Tod::TimeOfDay.new(1) }
+    assert_equal Tod::TimeOfDay.new(1), Tod::TimeOfDay.parse('25:00:00') { |time_string| Tod::TimeOfDay.parse(time_string.sub('25', '01')) }
   end
 
   it "provides spaceship operator" do

--- a/tod.gemspec
+++ b/tod.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "activerecord", ">= 3.0.0"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "pry"
+  s.add_development_dependency "pry-byebug"
   s.add_development_dependency "arel"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Hi,
we had the problem in rails 5, that rails uses the dump method of the serializer just on access of the attribute. If we had Inputparams that were unparsable we get an exception in that case and could not use the default validation control flow. Example:
```ruby
order = Order.new(time: 'foo')
order.valid?
=> ArgumentError: Invalid time of day string
order.time
=> ArgumentError: Invalid time of day string
```
To fix this we should catch the ArgumentError in the dump method and return nil, if the input is not parsable. That way we could add custom errors in the validation blocks, if the time value is nil, but the input params were not.