### PR TITLE
Add ability to use AR’s attribute API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add string formatting compatible with Rails (Tate Johnson)
+* Add ability to use ActiveRecord's attribute API (Brent Wheeldon)
 
 # 2.1.1 (April 14, 2017)
 

--- a/lib/tod.rb
+++ b/lib/tod.rb
@@ -1,3 +1,5 @@
 require 'tod/time_of_day'
 require 'tod/shift'
 require 'tod/conversions'
+
+require 'tod/railtie' if defined?(Rails)

--- a/lib/tod/railtie.rb
+++ b/lib/tod/railtie.rb
@@ -1,0 +1,9 @@
+require "tod/time_of_day_type"
+
+module Tod
+  class Railtie < Rails::Railtie
+    initializer "tod.register_active_record_type" do
+      ActiveRecord::Type.register(:time_only, Tod::TimeOfDayType)
+    end
+  end
+end

--- a/lib/tod/time_of_day_type.rb
+++ b/lib/tod/time_of_day_type.rb
@@ -1,0 +1,11 @@
+module Tod
+  class TimeOfDayType < ActiveRecord::Type::Value
+    def cast(value)
+      TimeOfDay.load(value)
+    end
+
+    def serialize(value)
+      TimeOfDay.dump(value)
+    end
+  end
+end


### PR DESCRIPTION
The attribute API allows us to specify custom types for fields and because of where it fits into the lifecycle we don't need to modify the `time_zone_aware_types` configuration.

Given there's not a tonne of logic here I didn't add any specs, but I'd be happy to add some in if you'd like.