### PR TITLE
Depend on ActiveModel instead of ActiveRecord

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -226,9 +226,9 @@ produce an object with the correct time and time zone, pass in an
     tod.on time, Time.find_zone!("US/Mountain")          # => Mon, 24 Sep 2018 08:30:00 MDT -06:00
     Date.tomorrow.at tod, Time.find_zone!("US/Mountain") # => Tue, 25 Sep 2018 08:30:00 MDT -06:00
 
-ActiveRecord Serializable Attribute Support
+ActiveModel Serializable Attribute Support
 =======================
-Tod::TimeOfDay implements a custom serialization contract for ActiveRecord serialize which allows to store Tod::TimeOfDay directly
+Tod::TimeOfDay implements a custom serialization contract for ActiveModel serialize which allows to store Tod::TimeOfDay directly
 in a column of the time type.
 
 Example:

--- a/lib/tod/railtie.rb
+++ b/lib/tod/railtie.rb
@@ -1,9 +1,10 @@
+require "active_model/type"
 require "tod/time_of_day_type"
 
 module Tod
   class Railtie < Rails::Railtie
-    initializer "tod.register_active_record_type" do
-      ActiveRecord::Type.register(:time_only, Tod::TimeOfDayType)
+    initializer "tod.register_active_model_type" do
+      ActiveModel::Type.register(:time_only, Tod::TimeOfDayType)
     end
   end
 end

--- a/lib/tod/time_of_day_type.rb
+++ b/lib/tod/time_of_day_type.rb
@@ -1,5 +1,5 @@
 module Tod
-  class TimeOfDayType < ActiveRecord::Type::Value
+  class TimeOfDayType < ActiveModel::Type::Value
     def cast(value)
       TimeOfDay.load(value)
     end


### PR DESCRIPTION
So that Tod will continue to work in Rails apps that don't have ActiveRecord enabled