### PR TITLE
Add method for use in Rails database quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add string formatting compatible with Rails (Tate Johnson)
 * Add ability to use ActiveRecord's attribute API (Brent Wheeldon)
+* Add method for use in Rails database quoting (Ben Jackson)
 
 # 2.1.1 (April 14, 2017)
 

--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -106,6 +106,10 @@ module Tod
     end
     alias_method :to_s, :to_formatted_s
 
+    def value_for_database
+      to_s
+    end
+
     # Return a new TimeOfDay num_seconds greater than self. It will wrap around
     # at midnight.
     def +(num_seconds)

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -176,6 +176,13 @@ describe "TimeOfDay" do
     end
   end
 
+  describe "value_for_database" do
+    it "returns a formatted value for database query serialization" do
+      t = Tod::TimeOfDay.new(12,15,05)
+      assert_equal "12:15:05", t.value_for_database
+    end
+  end
+
   describe "to_s" do
     it "is aliased to to_formatted_s" do
       t = Tod::TimeOfDay.new(8,15,30)


### PR DESCRIPTION
This adds a method `value_for_database` to the Tod::TimeOfDay class. When ActiveRecord is preparing to 'quote' an object for use in a SQL query, it asks the object if it responds to this method. If so, it calls `quote()` with the return value rather than with the object itself.

This will allow usage of instances of Tod::TimeOfDay when building queries:
```ruby
MyModel.where("open_at > ?", Tod::TimeOfDay.new(12, 30))
```