### PR TITLE
Freeze constants values

### DIFF
--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -34,19 +34,19 @@ module Tod
     /x
 
     WORDS = {
-      "noon" => "12pm",
-      "midnight" => "12am"
-    }
+      "noon" => "12pm".freeze,
+      "midnight" => "12am".freeze
+    }.freeze
 
     NUM_SECONDS_IN_DAY = 86400
     NUM_SECONDS_IN_HOUR = 3600
     NUM_SECONDS_IN_MINUTE = 60
 
     FORMATS = {
-      short: "%-l:%M %P",
-      medium: "%-l:%M:%S %P",
-      time: "%H:%M"
-    }
+      short: "%-l:%M %P".freeze,
+      medium: "%-l:%M:%S %P".freeze,
+      time: "%H:%M".freeze
+    }.freeze
 
     def initialize(h, m=0, s=0)
       @hour = Integer(h)
@@ -89,7 +89,7 @@ module Tod
     def strftime(format_string)
       # Special case 2400 because strftime will load TimeOfDay into Time which
       # will convert 24 to 0
-      format_string.gsub!(/%H|%k/, '24') if @hour == 24
+      format_string = format_string.gsub(/%H|%k/, '24') if @hour == 24
       Time.local(2000,1,1, @hour, @minute, @second).strftime(format_string)
     end
 


### PR DESCRIPTION
[That PR](https://github.com/jackc/tod/pull/54/files#diff-6c590515d408a867bb78c4681c5e6688R92) introduced a bug that mutates time formats inside `FORMATS` constant that leads to wrong results for all following calls that are using modified time format:
```ruby
irb(main):001:0> require 'tod'
=> true
irb(main):002:0> Tod::TimeOfDay.parse('24:00').to_s(:time) # or Tod::TimeOfDay.new(24)
=> "24:00"
irb(main):003:0> Tod::TimeOfDay.parse('13:30').to_s(:time) # should produce 13:30
=> "24:30"
```

This PR freezes constants and constant values to prevent mutation of time formats