### PR TITLE
Convert arguments of Tod::Shift

### DIFF
--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -12,21 +12,21 @@ module Tod
         raise ArgumentError, "exclude_end must be true or false"
       end
 
-      @beginning = beginning.is_a?(TimeOfDay) ? beginning : TimeOfDay(beginning)
-      @ending = ending.is_a?(TimeOfDay) ? ending : TimeOfDay(ending)
+      @beginning = beginning.is_a?(::Tod::TimeOfDay) ? beginning : ::Tod::TimeOfDay(beginning)
+      @ending = ending.is_a?(::Tod::TimeOfDay) ? ending : ::Tod::TimeOfDay(ending)
       @exclude_end = exclude_end
 
-      normalized_ending = ending.to_i
-      normalized_ending += TimeOfDay::NUM_SECONDS_IN_DAY if normalized_ending < beginning.to_i
+      normalized_ending = @ending.to_i
+      normalized_ending += TimeOfDay::NUM_SECONDS_IN_DAY if normalized_ending < @beginning.to_i
 
-      @range = Range.new(beginning.to_i, normalized_ending, @exclude_end)
+      @range = Range.new(@beginning.to_i, normalized_ending, @exclude_end)
 
       freeze # Shift instances are value objects
     end
 
     # Returns true if the time of day is inside the shift, false otherwise.
     def include?(tod)
-      second = tod.to_i
+      second = tod.is_a?(::Tod::TimeOfDay) ? tod.to_i : ::Tod::TimeOfDay(tod).to_i
       second += TimeOfDay::NUM_SECONDS_IN_DAY if second < @range.first
       @range.cover?(second)
     end

--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -12,8 +12,8 @@ module Tod
         raise ArgumentError, "exclude_end must be true or false"
       end
 
-      @beginning = beginning
-      @ending = ending
+      @beginning = beginning.is_a?(TimeOfDay) ? beginning : TimeOfDay(beginning)
+      @ending = ending.is_a?(TimeOfDay) ? ending : TimeOfDay(ending)
       @exclude_end = exclude_end
 
       normalized_ending = ending.to_i


### PR DESCRIPTION
`Tod::Shift` assumes that its arguments have type `Tod::TimeOfDay` but it does not really check it. So I guess it's a good idea to either raise an error if arguments have different type, or to try to convert them to correct type.

I chose to convert arguments so one could pass a `String` or `Time` to `Tod::Shift`