### PR TITLE
Allow any separator character(s) for 24H strings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,6 +46,15 @@ are all optional.
     Tod::TimeOfDay.parse "151253"                       # => 15:12:53
     Tod::TimeOfDay.parse "noon"                         # => 12:00:00
     Tod::TimeOfDay.parse "midnight"                     # => 00:00:00
+    
+Strings recognized as being in 24H format may optionally use any non-numeric
+character(s) as separators. (A string will be treated as 24H format unless it
+terminates with a meridian indicator)
+
+    Tod::TimeOfDay.parse "2300"                         # => 23:00:00
+    Tod::TimeOfDay.parse "23:00"                        # => 23:00:00
+    Tod::TimeOfDay.parse "23+00"                        # => 23:00:00
+    Tod::TimeOfDay.parse "23H30M58S"                    # => 23:30:58
 
 Tod::TimeOfDay.parse raises an ArgumentError if the argument to parse is not
 parsable. Tod::TimeOfDay.try_parse will instead return nil if the argument is not

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -63,7 +63,9 @@ describe "TimeOfDay" do
   should_parse "13",          13, 0, 0
   should_parse "1230",        12,30, 0
   should_parse "08:15",        8,15, 0
+  should_parse "08+15",        8,15, 0
   should_parse "08:15:30",     8,15,30
+  should_parse "08H15M30S",    8,15,30
   should_parse "18",          18, 0, 0
   should_parse "23",          23, 0, 0
 


### PR DESCRIPTION
When parsing a string in 24H format, any non-numeric
character(s) are permitted for use as separators.

resolves #70 