### PR TITLE
Add floor and ceiling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,7 +120,7 @@ Round to the given nearest number of seconds.
 Floor
 ----------
 
-Round down by given number of seconds
+Round down by given number of seconds.
 
     Tod::TimeOfDay.new(8,15,31).floor(5)     # => "08:15:30"
     Tod::TimeOfDay.new(8,15,34).floor(60)    # => "08:15:00"
@@ -129,7 +129,7 @@ Round down by given number of seconds
 Ceiling
 ----------
 
-Round up by given number of seconds
+Round up by given number of seconds.
 
     Tod::TimeOfDay.new(8,15,31).ceil(5)     # => "08:15:35"
     Tod::TimeOfDay.new(8,15,34).ceil(60)    # => "08:16:00"

--- a/README.markdown
+++ b/README.markdown
@@ -116,6 +116,24 @@ Round to the given nearest number of seconds.
     Tod::TimeOfDay.new(8,15,31).round(5)     # => "08:15:30"
     Tod::TimeOfDay.new(8,15,34).round(60)    # => "08:16:00"
     Tod::TimeOfDay.new(8,02,29).round(300)   # => "08:00:00"
+    
+Floor
+----------
+
+Round down by given seconds
+
+    Tod::TimeOfDay.new(8,15,31).floor(5)     # => "08:15:30"
+    Tod::TimeOfDay.new(8,15,34).floor(60)    # => "08:15:00"
+    Tod::TimeOfDay.new(8,02,29).floor(300)   # => "08:00:00"
+    
+Ceiling
+----------
+
+Round down by given seconds
+
+    Tod::TimeOfDay.new(8,15,31).ceil(5)     # => "08:15:35"
+    Tod::TimeOfDay.new(8,15,34).ceil(60)    # => "08:16:00"
+    Tod::TimeOfDay.new(8,02,29).ceil(300)   # => "08:05:00"
 
 Convenience methods for dates and times
 ---------------------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -120,7 +120,7 @@ Round to the given nearest number of seconds.
 Floor
 ----------
 
-Round down by given seconds
+Round down by given number of seconds
 
     Tod::TimeOfDay.new(8,15,31).floor(5)     # => "08:15:30"
     Tod::TimeOfDay.new(8,15,34).floor(60)    # => "08:15:00"
@@ -129,7 +129,7 @@ Round down by given seconds
 Ceiling
 ----------
 
-Round down by given seconds
+Round up by given number of seconds
 
     Tod::TimeOfDay.new(8,15,31).ceil(5)     # => "08:15:35"
     Tod::TimeOfDay.new(8,15,34).ceil(60)    # => "08:16:00"

--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -70,10 +70,20 @@ module Tod
       @second_of_day <=> other.second_of_day
     end
 
+    # Rounding down by number of seconds
+    def floor(sec = 1)
+      self - (self.to_i % round_sec)
+    end
+    
+    # Rounding up by number of seconds
+    def ceil(sec = 1)
+      floor(sec) + sec
+    end
+    
     # Rounding to the given nearest number of seconds
     def round(round_sec = 1)
-      down = self - (self.to_i % round_sec)
-      up = down + round_sec
+      down = floor(round_sec)
+      up = ceil(round_sec)
 
       difference_down = self - down
       difference_up = up - self


### PR DESCRIPTION
Add floor and ceiling methods to TimeOfDay. This is useful for scheduling things at specific time intervals after doing arithmetic. For example to only schedule things in 15-minute increments.