### PR TITLE
Register type to both ActiveModel and ActiveRecord

### DIFF
--- a/lib/tod/railtie.rb
+++ b/lib/tod/railtie.rb
@@ -8,7 +8,6 @@ module Tod
     initializer "tod.register_active_model_type" do
       if Rails.version[0] > "4"
         ActiveModel::Type.register(:time_only, Tod::TimeOfDayType)
-      else
         ActiveRecord::Type.register(:time_only, Tod::TimeOfDayType)
       end
     end


### PR DESCRIPTION
Hi there and thanks for Tod!

While upgrading to Rails 6.1 we ran into a weird issue with Tod. Apparently, a type registered in ActiveModel's registry was not available in ActiveRecord models. This might be a change in Rails (we couldn't identify it in the changelog), but it also might be load order quirk. Anyhow, various code examples in the Attributes API documentation suggest that a type should be registered both with ActiveModel and ActiveRecord registries—in fact all the native types are registered in both places.

Since Attributes API was introduced in Rails 5, `ActiveRecord::Type.register(:time_only, Tod::TimeOfDayType)` is only
supported since Rails 5—it's not a fallback for older versions of Rails. In fact there's [another open issue](https://github.com/jackc/tod/issues/61) where the conditional was causing issues.