### PR TITLE
Rename heading for #overlaps? to match method name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -182,7 +182,7 @@ Include?
     Tod::Shift.new(Tod::TimeOfDay.new(5), Tod::TimeOfDay.new(9), true).include?(Tod::TimeOfDay.new(9)) # => false
 
 
-Overlap?
+Overlaps?
 --------------------
 
     breakfast = Tod::Shift.new(Tod::TimeOfDay.new(8), Tod::TimeOfDay.new(11))


### PR DESCRIPTION
The section with the `#overlaps?` example is titled Overlap? This is presumed
to be a typo.

This commit fixes the typo so the section heading matches the method name.

See issue: https://github.com/jackc/tod/issues/87