### PR TITLE
Improve TimeOfDate#inspect and Shift#inspect

### DIFF
--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -24,6 +24,10 @@ module Tod
       freeze # Shift instances are value objects
     end
 
+    def inspect
+      "#<#{self.class} #{beginning}#{exclude_end? ? '...' : '..'}#{ending}>"
+    end
+
     # Returns true if the time of day is inside the shift, false otherwise.
     def include?(tod)
       second = tod.to_i

--- a/lib/tod/time_of_day.rb
+++ b/lib/tod/time_of_day.rb
@@ -112,6 +112,10 @@ module Tod
       to_s
     end
 
+    def inspect
+      "#<#{self.class} #{self}>"
+    end
+
     # Return a new TimeOfDay num_seconds greater than self. It will wrap around
     # at midnight.
     def +(num_seconds)

--- a/test/tod/shift_test.rb
+++ b/test/tod/shift_test.rb
@@ -11,6 +11,16 @@ describe "Shift" do
     end
   end
 
+  describe "inspect" do
+    it "provides friendly description" do
+      shift = Tod::Shift.new Tod::TimeOfDay.new(8), Tod::TimeOfDay.new(10), false
+      assert_equal "#<Tod::Shift 08:00:00..10:00:00>", shift.inspect
+
+      shift = Tod::Shift.new Tod::TimeOfDay.new(8), Tod::TimeOfDay.new(10), true
+      assert_equal "#<Tod::Shift 08:00:00...10:00:00>", shift.inspect
+    end
+  end
+
   describe "#duration" do
     it "returns correct duration when first time is lower than the second one" do
       duration_expected = 4 * 60 * 60 + 30 * 60 + 30 # 4 hours, 30 min and 30 sec later

--- a/test/tod/time_of_day_test.rb
+++ b/test/tod/time_of_day_test.rb
@@ -190,6 +190,13 @@ describe "TimeOfDay" do
     end
   end
 
+  describe "inspect" do
+    it "is friendly representation" do
+      t = Tod::TimeOfDay.new(12,15,05)
+      assert_equal "#<Tod::TimeOfDay 12:15:05>", t.inspect
+    end
+  end
+
   describe "to_i" do
     it "formats to integer" do
       assert_equal 29730, Tod::TimeOfDay.new(8,15,30).to_i


### PR DESCRIPTION
I believe that `#inspect` for "value objects" should be friendly and concise (well, I believe [a lot of things](https://github.com/zverok/good-value-object) about the value objects, but whatever :shrug:).

For example, playing with the gem in IRB:
```ruby
Tod::TimeOfDay.new(20, 14)
# before
# => #<Tod::TimeOfDay:0x000055b5a6dc95e0 @hour=20, @minute=14, @second=0, @second_of_day=72840>
# after
# => #<Tod::TimeOfDay 20:14:00>
```

The same goes about `p`-debugging, raising exceptions/writing logs with statements like `expected String, got #{real_value.inspect}`, and diffs in testing:
```ruby
require 'tod'

RSpec.describe 'diff demo' do
  it {
    expect({value: 1, time: Tod::TimeOfDay.new(20, 14)}).to eq({value: 2, time: Tod::TimeOfDay.new(20, 14)})
  }
end
```
Output (RSpec correctly decides what is really different—only `value:`—but when producing diff, uses `inspect`). Output:
```
       expected: {:time=>#<Tod::TimeOfDay:0x000056288afc0540 @hour=20, @minute=14, @second=0, @second_of_day=72840>, :value=>2}
            got: {:time=>#<Tod::TimeOfDay:0x000056288afc0658 @hour=20, @minute=14, @second=0, @second_of_day=72840>, :value=>1}
     
       (compared using ==)
     
       Diff:
       @@ -1,3 +1,3 @@
       -:time => #<Tod::TimeOfDay:0x000056288afc0540 @hour=20, @minute=14, @second=0, @second_of_day=72840>,
       -:value => 2,
       +:time => #<Tod::TimeOfDay:0x000056288afc0658 @hour=20, @minute=14, @second=0, @second_of_day=72840>,
       +:value => 1,
```

Output after my change:
```
      expected: {:time=>#<Tod::TimeOfDay 20:14:00>, :value=>2}
            got: {:time=>#<Tod::TimeOfDay 20:14:00>, :value=>1}
     
       (compared using ==)
     
       Diff:
       @@ -1,3 +1,3 @@
        :time => #<Tod::TimeOfDay 20:14:00>,
       -:value => 2,
       +:value => 1,
```
(Note that both `expected`/`got` pair is easier to read now, and the diff correctly understands the `time:` key is the same)