### PR TITLE
Shift#contains? doesn't consider exclusive ending in given shift

### DIFF
--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -74,7 +74,10 @@ module Tod
     end
 
     def contains?(shift)
-      self.include?(shift.beginning) && self.include?(shift.ending)
+      inclusive_ending = shift.ending
+      inclusive_ending -= 1.second if shift.exclude_end?
+
+      self.include?(shift.beginning) && self.include?(inclusive_ending)
     end
 
     # Return shift duration in seconds.

--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -104,9 +104,11 @@ module Tod
       self.class.new(beginning + seconds, ending + seconds, exclude_end?)
     end
 
+    protected
+
     # Returns equivalent inclusive ending to existent exclusive ending
     def inclusive_ending
-      self.exclude_end? ? ending - 1.second : ending
+      self.exclude_end? ? ending - 1 : ending
     end
   end
 end

--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -106,7 +106,7 @@ module Tod
 
     protected
 
-    # Returns equivalent inclusive ending to existent exclusive ending
+    # If exclusive ending returns equivalent ending but inclusive
     def inclusive_ending
       self.exclude_end? ? ending - 1 : ending
     end

--- a/lib/tod/shift.rb
+++ b/lib/tod/shift.rb
@@ -74,10 +74,7 @@ module Tod
     end
 
     def contains?(shift)
-      inclusive_ending = shift.ending
-      inclusive_ending -= 1.second if shift.exclude_end?
-
-      self.include?(shift.beginning) && self.include?(inclusive_ending)
+      self.include?(shift.beginning) && self.include?(shift.inclusive_ending)
     end
 
     # Return shift duration in seconds.
@@ -105,6 +102,11 @@ module Tod
     # Move start and end by a number of seconds and return new shift.
     def slide(seconds)
       self.class.new(beginning + seconds, ending + seconds, exclude_end?)
+    end
+
+    # Returns equivalent inclusive ending to existent exclusive ending
+    def inclusive_ending
+      self.exclude_end? ? ending - 1.second : ending
     end
   end
 end

--- a/test/tod/shift_test.rb
+++ b/test/tod/shift_test.rb
@@ -173,7 +173,7 @@ describe "Shift" do
       refute shift1.contains?(shift2)
     end
 
-    it "it is true when beginning is included and exclusive endings match" do
+    it "is true when beginning is included and exclusive endings match" do
       inside = Tod::Shift.new(Tod::TimeOfDay.new(13), Tod::TimeOfDay.new(17), true)
       outside = Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(17), true)
       assert outside.contains?(inside)

--- a/test/tod/shift_test.rb
+++ b/test/tod/shift_test.rb
@@ -172,6 +172,12 @@ describe "Shift" do
       shift2 = Tod::Shift.new(Tod::TimeOfDay.new(18), Tod::TimeOfDay.new(19))
       refute shift1.contains?(shift2)
     end
+
+    it "it is true when beginning is included and exclusive endings match" do
+      inside = Tod::Shift.new(Tod::TimeOfDay.new(13), Tod::TimeOfDay.new(17), true)
+      outside = Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(17), true)
+      assert outside.contains?(inside)
+    end
   end
 
   describe "#include?" do


### PR DESCRIPTION
Hey, how are you? I love how concise and fundamental is this gem.
I'd like to share what I consider is a little bug.

I think that this should be true for `shift#contains?`
`[13, 16:59:59] ⊂ [10, 16:59:59] => [13, 17) ⊂ [10, 17)`
In human: If matching inclusive endings satisfy the `contains?` then matching exclusive endings should do it too.