### PR TITLE
Allow use in rails forms with time_select

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -244,6 +244,18 @@ order = Order.create(time: Tod::TimeOfDay.new(9,30))
 order.time                                      # => 09:30:00
 ```
 
+In Rails, this can be used with `time_select` in forms like so:
+
+```ruby
+f.time_select :time, ignore_date: true
+```
+
+Or with **simple_form**:
+
+```ruby
+f.input :time, as: :time, ignore_date: true
+```
+
 MongoDB Support
 ===============
 

--- a/lib/tod/time_of_day_type.rb
+++ b/lib/tod/time_of_day_type.rb
@@ -4,7 +4,7 @@ module Tod
       if value.is_a? Hash
           # rails multiparam attribute
           # get hour, minute and second and construct new TimeOfDay object
-        ::Tod::TimeOfDay.new(value[4], value[5], value[6])
+        ::Tod::TimeOfDay.new(value[4], value[5], value[6] || 0)
       else
         # return nil, if input is not parsable
         Tod::TimeOfDay(value){}

--- a/test/tod/time_of_day_attribute_test.rb
+++ b/test/tod/time_of_day_attribute_test.rb
@@ -24,6 +24,11 @@ describe "TimeOfDay with ActiveRecord Attribute" do
     assert_equal Tod::TimeOfDay.new(8,6,5), order.time
   end
 
+  it "works with multiparam time arguments without seconds" do
+    order = Order.create!({"time(4i)" => "8", "time(5i)" => "6"})
+    assert_equal Tod::TimeOfDay.new(8,6,0), order.time
+  end
+
   it "should not raise Exception on access of unparsable values" do
     order = Order.new(time: 'unparsable')
     order.time


### PR DESCRIPTION
As requested by #83, this allows Tod time `attribute`s to be easily included in Rails forms. Let me know if you need any changes! 